### PR TITLE
New Sendy API Integration to Fully Remove Users from List

### DIFF
--- a/src/Sendy.php
+++ b/src/Sendy.php
@@ -160,6 +160,46 @@ class Sendy
     }
 
     /**
+     * Method to delete a user from a list
+     *
+     * @param $email
+     *
+     * @return array
+     */
+    public function delete($email)
+    {
+        $result = $this->buildAndSend('/api/subscribers/delete.php', ['email' => $email]);
+
+        /**
+         * Prepare the array to return
+         */
+        $notice = [
+            'status' => true,
+            'message' => '',
+        ];
+
+        /**
+         * Handle results
+         */
+        switch (strval($result)) {
+            case '1':
+                $notice['message'] = 'Deleted';
+
+                break;
+            default:
+                $notice = [
+                    'status' => false,
+                    'message' => $result
+                ];
+
+                break;
+        }
+
+        return $notice;
+    }
+
+
+    /**
      * Method to get the current status of a subscriber.
      * Success: Subscribed, Unsubscribed, Unconfirmed, Bounced, Soft bounced, Complained
      * Error: No data passed, Email does not exist in list, etc.

--- a/tests/SendyTest.php
+++ b/tests/SendyTest.php
@@ -87,4 +87,22 @@ class SendyTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(true, $subscriber['status']);
         $this->assertEquals('Already subscribed.', $subscriber['message']);
     }
+
+    public function testDelete()
+    {
+        $subscriber = new Sendy($this->config);
+        $subscriber->subscribe([
+            'name' => 'Mark',
+            'email' => 'mark@gmail.com',
+        ]);
+        $currentStatus = $subscriber->status('mark@gmail.com');
+        $this->assertEquals('Subscribed', $currentStatus);
+
+        $deleteResult = $subscriber->delete('mark@gmail.com');
+        $this->assertEquals(true, $deleteResult['status']);
+
+        $currentStatus = $subscriber->status('mark@gmail.com');
+        $this->assertEquals('Email does not exist in list', $currentStatus);
+
+    }
 }


### PR DESCRIPTION
The current version of Sendy includes an API to completely remove a user from the list, rather than just unsubscribing them. This update implements the method to call this API and adds a corresponding test.

https://sendy.co/api#delete-subscriber